### PR TITLE
Shorten release store prefix

### DIFF
--- a/__tests__/release/__snapshots__/release-bin-minimal-test.js.snap
+++ b/__tests__/release/__snapshots__/release-bin-minimal-test.js.snap
@@ -13,13 +13,26 @@ exports[`installation 1`] = `
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
-| | | | records
-| | | | | recordedClientBuildStorePath.txt
-| | | | | recordedClientInstallStorePath.txt
-| | | | | recordedCoppiedArtifacts.txt
-| | | | | recordedServerBuildStorePath.txt
-| | | | rel
-| | | | | 3.x.x______________________________
+| | | | r
+| | | | | _esyEjectRoot
+| | | | | | bin
+| | | | | | | fastreplacestring.cpp
+| | | | | | | fastreplacestring.exe
+| | | | | | | get-store-path
+| | | | | | | realpath
+| | | | | | | realpath.c
+| | | | | | | render-env
+| | | | | | | runtime.sh
+| | | | | | command-env
+| | | | | | eject-env
+| | | | | | Makefile
+| | | | | | records
+| | | | | | | final-install-path-set.txt
+| | | | | | | final-install-path-set.txt.in
+| | | | | | | store-path.txt
+| | | | | | | store-path.txt.in
+| | | | | | sandbox.sb.in
+| | | | | 3__________________________________
 | | | | | | i
 | | | | | | | minimal-0.1.0
 | | | | | | | | bin
@@ -32,30 +45,18 @@ exports[`installation 1`] = `
 | | | | | node_modules
 | | | | | | .cache
 | | | | | | | _esy
-| | | | | | | | build-eject
-| | | | | | | | | bin
-| | | | | | | | | | fastreplacestring.cpp
-| | | | | | | | | | fastreplacestring.exe
-| | | | | | | | | | get-store-path
-| | | | | | | | | | realpath
-| | | | | | | | | | realpath.c
-| | | | | | | | | | render-env
-| | | | | | | | | | runtime.sh
-| | | | | | | | | command-env
-| | | | | | | | | eject-env
-| | | | | | | | | Makefile
-| | | | | | | | | records
-| | | | | | | | | | final-install-path-set.txt
-| | | | | | | | | | final-install-path-set.txt.in
-| | | | | | | | | | store-path.txt
-| | | | | | | | | | store-path.txt.in
-| | | | | | | | | sandbox.sb.in
 | | | | | | | | store
 | | | | | | | | | b
 | | | | | | | | | i
 | | | | | | | | | s
 | | | | | package.json
-| | | | | test.js"
+| | | | | test.js
+| | | | records
+| | | | | done.txt
+| | | | | recordedClientBuildStorePath.txt
+| | | | | recordedClientInstallStorePath.txt
+| | | | | recordedCoppiedArtifacts.txt
+| | | | | recordedServerBuildStorePath.txt"
 `;
 
 exports[`installation stdout 1`] = `
@@ -78,11 +79,11 @@ exports[`release 1`] = `
 | | package.json
 | | postinstall.sh
 | | prerelease.sh
+| | r.tar.gz
 | | records
 | | | recordedClientBuildStorePath.txt
 | | | recordedCoppiedArtifacts.txt
 | | | recordedServerBuildStorePath.txt
-| | rel.tar.gz
 | | relBinaries
 | | | i
 | | | | minimal-0.1.0.tar.gz"
@@ -94,5 +95,9 @@ exports[`release stdout 1`] = `
 *** Ejecting build environment...
 *** Building the release...
 [1;37m*** minimal @ 0.1.0: building from source...[0m
-[0;32m*** minimal @ 0.1.0: build complete[0m"
+[0;32m*** minimal @ 0.1.0: build complete[0m
+*** Release package created
+
+    Location: _release/bin-darwin
+    Release Type: bin"
 `;

--- a/__tests__/release/__snapshots__/release-bin-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-bin-with-binary-test.js.snap
@@ -15,13 +15,26 @@ exports[`installation 1`] = `
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
-| | | | records
-| | | | | recordedClientBuildStorePath.txt
-| | | | | recordedClientInstallStorePath.txt
-| | | | | recordedCoppiedArtifacts.txt
-| | | | | recordedServerBuildStorePath.txt
-| | | | rel
-| | | | | 3.x.x__________________________
+| | | | r
+| | | | | _esyEjectRoot
+| | | | | | bin
+| | | | | | | fastreplacestring.cpp
+| | | | | | | fastreplacestring.exe
+| | | | | | | get-store-path
+| | | | | | | realpath
+| | | | | | | realpath.c
+| | | | | | | render-env
+| | | | | | | runtime.sh
+| | | | | | command-env
+| | | | | | eject-env
+| | | | | | Makefile
+| | | | | | records
+| | | | | | | final-install-path-set.txt
+| | | | | | | final-install-path-set.txt.in
+| | | | | | | store-path.txt
+| | | | | | | store-path.txt.in
+| | | | | | sandbox.sb.in
+| | | | | 3______________________________
 | | | | | | i
 | | | | | | | with_binary-0.1.0
 | | | | | | | | bin
@@ -35,31 +48,19 @@ exports[`installation 1`] = `
 | | | | | node_modules
 | | | | | | .cache
 | | | | | | | _esy
-| | | | | | | | build-eject
-| | | | | | | | | bin
-| | | | | | | | | | fastreplacestring.cpp
-| | | | | | | | | | fastreplacestring.exe
-| | | | | | | | | | get-store-path
-| | | | | | | | | | realpath
-| | | | | | | | | | realpath.c
-| | | | | | | | | | render-env
-| | | | | | | | | | runtime.sh
-| | | | | | | | | command-env
-| | | | | | | | | eject-env
-| | | | | | | | | Makefile
-| | | | | | | | | records
-| | | | | | | | | | final-install-path-set.txt
-| | | | | | | | | | final-install-path-set.txt.in
-| | | | | | | | | | store-path.txt
-| | | | | | | | | | store-path.txt.in
-| | | | | | | | | sandbox.sb.in
 | | | | | | | | store
 | | | | | | | | | b
 | | | | | | | | | i
 | | | | | | | | | s
 | | | | | package.json
 | | | | | say-hello.exe
-| | | | | test.js"
+| | | | | test.js
+| | | | records
+| | | | | done.txt
+| | | | | recordedClientBuildStorePath.txt
+| | | | | recordedClientInstallStorePath.txt
+| | | | | recordedCoppiedArtifacts.txt
+| | | | | recordedServerBuildStorePath.txt"
 `;
 
 exports[`installation stdout 1`] = `
@@ -84,11 +85,11 @@ exports[`release 1`] = `
 | | package.json
 | | postinstall.sh
 | | prerelease.sh
+| | r.tar.gz
 | | records
 | | | recordedClientBuildStorePath.txt
 | | | recordedCoppiedArtifacts.txt
 | | | recordedServerBuildStorePath.txt
-| | rel.tar.gz
 | | relBinaries
 | | | i
 | | | | with_binary-0.1.0.tar.gz"
@@ -100,5 +101,9 @@ exports[`release stdout 1`] = `
 *** Ejecting build environment...
 *** Building the release...
 [1;37m*** with-binary @ 0.1.0: building from source...[0m
-[0;32m*** with-binary @ 0.1.0: build complete[0m"
+[0;32m*** with-binary @ 0.1.0: build complete[0m
+*** Release package created
+
+    Location: _release/bin-darwin
+    Release Type: bin"
 `;

--- a/__tests__/release/__snapshots__/release-bin-with-dep-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-bin-with-dep-with-binary-test.js.snap
@@ -15,13 +15,30 @@ exports[`installation 1`] = `
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
-| | | | records
-| | | | | recordedClientBuildStorePath.txt
-| | | | | recordedClientInstallStorePath.txt
-| | | | | recordedCoppiedArtifacts.txt
-| | | | | recordedServerBuildStorePath.txt
-| | | | rel
-| | | | | 3.x.x_________________
+| | | | r
+| | | | | _esyEjectRoot
+| | | | | | bin
+| | | | | | | fastreplacestring.cpp
+| | | | | | | fastreplacestring.exe
+| | | | | | | get-store-path
+| | | | | | | realpath
+| | | | | | | realpath.c
+| | | | | | | render-env
+| | | | | | | runtime.sh
+| | | | | | command-env
+| | | | | | eject-env
+| | | | | | Makefile
+| | | | | | node_modules
+| | | | | | | dep
+| | | | | | | | eject-env
+| | | | | | | | sandbox.sb.in
+| | | | | | records
+| | | | | | | final-install-path-set.txt
+| | | | | | | final-install-path-set.txt.in
+| | | | | | | store-path.txt
+| | | | | | | store-path.txt.in
+| | | | | | sandbox.sb.in
+| | | | | 3_____________________
 | | | | | | i
 | | | | | | | dep-0.1.0
 | | | | | | | | bin
@@ -44,38 +61,22 @@ exports[`installation 1`] = `
 | | | | | | dep
 | | | | | | | package.json
 | | | | | | | say-hello.exe
+| | | | | esy.lock
 | | | | | node_modules
 | | | | | | .cache
 | | | | | | | _esy
-| | | | | | | | build-eject
-| | | | | | | | | bin
-| | | | | | | | | | fastreplacestring.cpp
-| | | | | | | | | | fastreplacestring.exe
-| | | | | | | | | | get-store-path
-| | | | | | | | | | realpath
-| | | | | | | | | | realpath.c
-| | | | | | | | | | render-env
-| | | | | | | | | | runtime.sh
-| | | | | | | | | command-env
-| | | | | | | | | eject-env
-| | | | | | | | | Makefile
-| | | | | | | | | node_modules
-| | | | | | | | | | dep
-| | | | | | | | | | | eject-env
-| | | | | | | | | | | sandbox.sb.in
-| | | | | | | | | records
-| | | | | | | | | | final-install-path-set.txt
-| | | | | | | | | | final-install-path-set.txt.in
-| | | | | | | | | | store-path.txt
-| | | | | | | | | | store-path.txt.in
-| | | | | | | | | sandbox.sb.in
 | | | | | | | | store
 | | | | | | | | | b
 | | | | | | | | | i
 | | | | | | | | | s
 | | | | | package.json
 | | | | | test.js
-| | | | | yarn.lock"
+| | | | records
+| | | | | done.txt
+| | | | | recordedClientBuildStorePath.txt
+| | | | | recordedClientInstallStorePath.txt
+| | | | | recordedCoppiedArtifacts.txt
+| | | | | recordedServerBuildStorePath.txt"
 `;
 
 exports[`installation stdout 1`] = `
@@ -100,11 +101,11 @@ exports[`release 1`] = `
 | | package.json
 | | postinstall.sh
 | | prerelease.sh
+| | r.tar.gz
 | | records
 | | | recordedClientBuildStorePath.txt
 | | | recordedCoppiedArtifacts.txt
 | | | recordedServerBuildStorePath.txt
-| | rel.tar.gz
 | | relBinaries
 | | | i
 | | | | dep-0.1.0.tar.gz
@@ -119,5 +120,9 @@ exports[`release stdout 1`] = `
 [1;37m*** dep @ 0.1.0: building from source...[0m
 [0;32m*** dep @ 0.1.0: build complete[0m
 [1;37m*** with-dep-with-binary @ 0.1.0: building from source...[0m
-[0;32m*** with-dep-with-binary @ 0.1.0: build complete[0m"
+[0;32m*** with-dep-with-binary @ 0.1.0: build complete[0m
+*** Release package created
+
+    Location: _release/bin-darwin
+    Release Type: bin"
 `;

--- a/__tests__/release/__snapshots__/release-dev-minimal-test.js.snap
+++ b/__tests__/release/__snapshots__/release-dev-minimal-test.js.snap
@@ -8,18 +8,60 @@ exports[`installation 1`] = `
 | lib
 | | node_modules
 | | | minimal
+| | | | _esy
+| | | | | bin
+| | | | | | esy
+| | | | | etc
+| | | | | lib
+| | | | | | node_modules
+| | | | | | | esy
+| | | | | | | | _esyInstallCache-3.x.x
+| | | | | | | | | v1
+| | | | | | | | | | .tmp
+| | | | | | | | bin
+| | | | | | | | | esy
+| | | | | | | | | esy.js
+| | | | | | | | node_modules
+| | | | | | | | | .bin
+| | | | | | | | | | esy-install
+| | | | | | | | | @esy-ocaml
+| | | | | | | | | | esy-install
+| | | | | | | | | | | bin
+| | | | | | | | | | | | esy-install
+| | | | | | | | | | | | esy-install.js
+| | | | | | | | | | | package.json
+| | | | | | | | | | esy-opam
+| | | | | | | | | | | dist
+| | | | | | | | | | | | esy-opam.js
+| | | | | | | | | | | | esy-opam.js.flow
+| | | | | | | | | | | package.json
+| | | | | | | | | | | README.md
+| | | | | | | | package.json
 | | | | .bin
 | | | | | minimal-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
-| | | | records
-| | | | | recordedClientBuildStorePath.txt
-| | | | | recordedClientInstallStorePath.txt
-| | | | | recordedCoppiedArtifacts.txt
-| | | | | recordedServerBuildStorePath.txt
-| | | | rel
-| | | | | 3.x.x______________________________
+| | | | r
+| | | | | _esyEjectRoot
+| | | | | | bin
+| | | | | | | fastreplacestring.cpp
+| | | | | | | fastreplacestring.exe
+| | | | | | | get-store-path
+| | | | | | | realpath
+| | | | | | | realpath.c
+| | | | | | | render-env
+| | | | | | | runtime.sh
+| | | | | | command-env
+| | | | | | eject-env
+| | | | | | Makefile
+| | | | | | records
+| | | | | | | final-install-path-set.txt
+| | | | | | | final-install-path-set.txt.in
+| | | | | | | store-path.txt
+| | | | | | | store-path.txt.in
+| | | | | | sandbox.sb.in
+| | | | | 3__________________________________
 | | | | | | i
 | | | | | | | minimal-0.1.0
 | | | | | | | | bin
@@ -32,30 +74,18 @@ exports[`installation 1`] = `
 | | | | | node_modules
 | | | | | | .cache
 | | | | | | | _esy
-| | | | | | | | build-eject
-| | | | | | | | | bin
-| | | | | | | | | | fastreplacestring.cpp
-| | | | | | | | | | fastreplacestring.exe
-| | | | | | | | | | get-store-path
-| | | | | | | | | | realpath
-| | | | | | | | | | realpath.c
-| | | | | | | | | | render-env
-| | | | | | | | | | runtime.sh
-| | | | | | | | | command-env
-| | | | | | | | | eject-env
-| | | | | | | | | Makefile
-| | | | | | | | | records
-| | | | | | | | | | final-install-path-set.txt
-| | | | | | | | | | final-install-path-set.txt.in
-| | | | | | | | | | store-path.txt
-| | | | | | | | | | store-path.txt.in
-| | | | | | | | | sandbox.sb.in
 | | | | | | | | store
 | | | | | | | | | b
 | | | | | | | | | i
 | | | | | | | | | s
 | | | | | package.json
-| | | | | test.js"
+| | | | | test.js
+| | | | records
+| | | | | done.txt
+| | | | | recordedClientBuildStorePath.txt
+| | | | | recordedClientInstallStorePath.txt
+| | | | | recordedCoppiedArtifacts.txt
+| | | | | recordedServerBuildStorePath.txt"
 `;
 
 exports[`installation stdout 1`] = `
@@ -85,9 +115,16 @@ exports[`release 1`] = `
 | | package.json
 | | postinstall.sh
 | | prerelease.sh
-| | rel
+| | r
 | | | package.json
-| | | test.js"
+| | | test.js
+| | records"
 `;
 
-exports[`release stdout 1`] = `"*** Creating dev-type release for minimal..."`;
+exports[`release stdout 1`] = `
+"*** Creating dev-type release for minimal...
+*** Release package created
+
+    Location: _release/dev
+    Release Type: dev"
+`;

--- a/__tests__/release/__snapshots__/release-dev-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-dev-with-binary-test.js.snap
@@ -9,19 +9,61 @@ exports[`installation 1`] = `
 | lib
 | | node_modules
 | | | with-binary
+| | | | _esy
+| | | | | bin
+| | | | | | esy
+| | | | | etc
+| | | | | lib
+| | | | | | node_modules
+| | | | | | | esy
+| | | | | | | | _esyInstallCache-3.x.x
+| | | | | | | | | v1
+| | | | | | | | | | .tmp
+| | | | | | | | bin
+| | | | | | | | | esy
+| | | | | | | | | esy.js
+| | | | | | | | node_modules
+| | | | | | | | | .bin
+| | | | | | | | | | esy-install
+| | | | | | | | | @esy-ocaml
+| | | | | | | | | | esy-install
+| | | | | | | | | | | bin
+| | | | | | | | | | | | esy-install
+| | | | | | | | | | | | esy-install.js
+| | | | | | | | | | | package.json
+| | | | | | | | | | esy-opam
+| | | | | | | | | | | dist
+| | | | | | | | | | | | esy-opam.js
+| | | | | | | | | | | | esy-opam.js.flow
+| | | | | | | | | | | package.json
+| | | | | | | | | | | README.md
+| | | | | | | | package.json
 | | | | .bin
 | | | | | say-hello.exe
 | | | | | with-binary-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
-| | | | records
-| | | | | recordedClientBuildStorePath.txt
-| | | | | recordedClientInstallStorePath.txt
-| | | | | recordedCoppiedArtifacts.txt
-| | | | | recordedServerBuildStorePath.txt
-| | | | rel
-| | | | | 3.x.x__________________________
+| | | | r
+| | | | | _esyEjectRoot
+| | | | | | bin
+| | | | | | | fastreplacestring.cpp
+| | | | | | | fastreplacestring.exe
+| | | | | | | get-store-path
+| | | | | | | realpath
+| | | | | | | realpath.c
+| | | | | | | render-env
+| | | | | | | runtime.sh
+| | | | | | command-env
+| | | | | | eject-env
+| | | | | | Makefile
+| | | | | | records
+| | | | | | | final-install-path-set.txt
+| | | | | | | final-install-path-set.txt.in
+| | | | | | | store-path.txt
+| | | | | | | store-path.txt.in
+| | | | | | sandbox.sb.in
+| | | | | 3______________________________
 | | | | | | i
 | | | | | | | with_binary-0.1.0
 | | | | | | | | bin
@@ -35,31 +77,19 @@ exports[`installation 1`] = `
 | | | | | node_modules
 | | | | | | .cache
 | | | | | | | _esy
-| | | | | | | | build-eject
-| | | | | | | | | bin
-| | | | | | | | | | fastreplacestring.cpp
-| | | | | | | | | | fastreplacestring.exe
-| | | | | | | | | | get-store-path
-| | | | | | | | | | realpath
-| | | | | | | | | | realpath.c
-| | | | | | | | | | render-env
-| | | | | | | | | | runtime.sh
-| | | | | | | | | command-env
-| | | | | | | | | eject-env
-| | | | | | | | | Makefile
-| | | | | | | | | records
-| | | | | | | | | | final-install-path-set.txt
-| | | | | | | | | | final-install-path-set.txt.in
-| | | | | | | | | | store-path.txt
-| | | | | | | | | | store-path.txt.in
-| | | | | | | | | sandbox.sb.in
 | | | | | | | | store
 | | | | | | | | | b
 | | | | | | | | | i
 | | | | | | | | | s
 | | | | | package.json
 | | | | | say-hello.exe
-| | | | | test.js"
+| | | | | test.js
+| | | | records
+| | | | | done.txt
+| | | | | recordedClientBuildStorePath.txt
+| | | | | recordedClientInstallStorePath.txt
+| | | | | recordedCoppiedArtifacts.txt
+| | | | | recordedServerBuildStorePath.txt"
 `;
 
 exports[`installation stdout 1`] = `
@@ -91,10 +121,17 @@ exports[`release 1`] = `
 | | package.json
 | | postinstall.sh
 | | prerelease.sh
-| | rel
+| | r
 | | | package.json
 | | | say-hello.exe
-| | | test.js"
+| | | test.js
+| | records"
 `;
 
-exports[`release stdout 1`] = `"*** Creating dev-type release for with-binary..."`;
+exports[`release stdout 1`] = `
+"*** Creating dev-type release for with-binary...
+*** Release package created
+
+    Location: _release/dev
+    Release Type: dev"
+`;

--- a/__tests__/release/__snapshots__/release-dev-with-dep-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-dev-with-dep-with-binary-test.js.snap
@@ -9,19 +9,69 @@ exports[`installation 1`] = `
 | lib
 | | node_modules
 | | | with-dep-with-binary
+| | | | _esy
+| | | | | bin
+| | | | | | esy
+| | | | | etc
+| | | | | lib
+| | | | | | node_modules
+| | | | | | | esy
+| | | | | | | | _esyInstallCache-3.x.x
+| | | | | | | | | v1
+| | | | | | | | | | .tmp
+| | | | | | | | | | npm-dep-0.1.0-4d8a13d2-db68-4b0e-b2b9-3b4864c18437-1509317564180
+| | | | | | | | | | | .yarn-metadata.json
+| | | | | | | | | | | package.json
+| | | | | | | | | | | say-hello.exe
+| | | | | | | | bin
+| | | | | | | | | esy
+| | | | | | | | | esy.js
+| | | | | | | | node_modules
+| | | | | | | | | .bin
+| | | | | | | | | | esy-install
+| | | | | | | | | @esy-ocaml
+| | | | | | | | | | esy-install
+| | | | | | | | | | | bin
+| | | | | | | | | | | | esy-install
+| | | | | | | | | | | | esy-install.js
+| | | | | | | | | | | package.json
+| | | | | | | | | | esy-opam
+| | | | | | | | | | | dist
+| | | | | | | | | | | | esy-opam.js
+| | | | | | | | | | | | esy-opam.js.flow
+| | | | | | | | | | | package.json
+| | | | | | | | | | | README.md
+| | | | | | | | package.json
 | | | | .bin
 | | | | | say-hello.exe
 | | | | | with-dep-with-binary-esy-sandbox
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
-| | | | records
-| | | | | recordedClientBuildStorePath.txt
-| | | | | recordedClientInstallStorePath.txt
-| | | | | recordedCoppiedArtifacts.txt
-| | | | | recordedServerBuildStorePath.txt
-| | | | rel
-| | | | | 3.x.x_________________
+| | | | r
+| | | | | _esyEjectRoot
+| | | | | | bin
+| | | | | | | fastreplacestring.cpp
+| | | | | | | fastreplacestring.exe
+| | | | | | | get-store-path
+| | | | | | | realpath
+| | | | | | | realpath.c
+| | | | | | | render-env
+| | | | | | | runtime.sh
+| | | | | | command-env
+| | | | | | eject-env
+| | | | | | Makefile
+| | | | | | node_modules
+| | | | | | | dep
+| | | | | | | | eject-env
+| | | | | | | | sandbox.sb.in
+| | | | | | records
+| | | | | | | final-install-path-set.txt
+| | | | | | | final-install-path-set.txt.in
+| | | | | | | store-path.txt
+| | | | | | | store-path.txt.in
+| | | | | | sandbox.sb.in
+| | | | | 3_____________________
 | | | | | | i
 | | | | | | | dep-0.1.0
 | | | | | | | | bin
@@ -44,38 +94,22 @@ exports[`installation 1`] = `
 | | | | | | dep
 | | | | | | | package.json
 | | | | | | | say-hello.exe
+| | | | | esy.lock
 | | | | | node_modules
 | | | | | | .cache
 | | | | | | | _esy
-| | | | | | | | build-eject
-| | | | | | | | | bin
-| | | | | | | | | | fastreplacestring.cpp
-| | | | | | | | | | fastreplacestring.exe
-| | | | | | | | | | get-store-path
-| | | | | | | | | | realpath
-| | | | | | | | | | realpath.c
-| | | | | | | | | | render-env
-| | | | | | | | | | runtime.sh
-| | | | | | | | | command-env
-| | | | | | | | | eject-env
-| | | | | | | | | Makefile
-| | | | | | | | | node_modules
-| | | | | | | | | | dep
-| | | | | | | | | | | eject-env
-| | | | | | | | | | | sandbox.sb.in
-| | | | | | | | | records
-| | | | | | | | | | final-install-path-set.txt
-| | | | | | | | | | final-install-path-set.txt.in
-| | | | | | | | | | store-path.txt
-| | | | | | | | | | store-path.txt.in
-| | | | | | | | | sandbox.sb.in
 | | | | | | | | store
 | | | | | | | | | b
 | | | | | | | | | i
 | | | | | | | | | s
 | | | | | package.json
 | | | | | test.js
-| | | | | yarn.lock"
+| | | | records
+| | | | | done.txt
+| | | | | recordedClientBuildStorePath.txt
+| | | | | recordedClientInstallStorePath.txt
+| | | | | recordedCoppiedArtifacts.txt
+| | | | | recordedServerBuildStorePath.txt"
 `;
 
 exports[`installation stdout 1`] = `
@@ -109,13 +143,20 @@ exports[`release 1`] = `
 | | package.json
 | | postinstall.sh
 | | prerelease.sh
-| | rel
+| | r
 | | | dependencies
 | | | | dep
 | | | | | package.json
 | | | | | say-hello.exe
 | | | package.json
-| | | test.js"
+| | | test.js
+| | records"
 `;
 
-exports[`release stdout 1`] = `"*** Creating dev-type release for with-dep-with-binary..."`;
+exports[`release stdout 1`] = `
+"*** Creating dev-type release for with-dep-with-binary...
+*** Release package created
+
+    Location: _release/dev
+    Release Type: dev"
+`;

--- a/__tests__/release/__snapshots__/release-pack-minimal-test.js.snap
+++ b/__tests__/release/__snapshots__/release-pack-minimal-test.js.snap
@@ -13,13 +13,26 @@ exports[`installation 1`] = `
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
-| | | | records
-| | | | | recordedClientBuildStorePath.txt
-| | | | | recordedClientInstallStorePath.txt
-| | | | | recordedCoppiedArtifacts.txt
-| | | | | recordedServerBuildStorePath.txt
-| | | | rel
-| | | | | 3.x.x______________________________
+| | | | r
+| | | | | _esyEjectRoot
+| | | | | | bin
+| | | | | | | fastreplacestring.cpp
+| | | | | | | fastreplacestring.exe
+| | | | | | | get-store-path
+| | | | | | | realpath
+| | | | | | | realpath.c
+| | | | | | | render-env
+| | | | | | | runtime.sh
+| | | | | | command-env
+| | | | | | eject-env
+| | | | | | Makefile
+| | | | | | records
+| | | | | | | final-install-path-set.txt
+| | | | | | | final-install-path-set.txt.in
+| | | | | | | store-path.txt
+| | | | | | | store-path.txt.in
+| | | | | | sandbox.sb.in
+| | | | | 3__________________________________
 | | | | | | i
 | | | | | | | minimal-0.1.0
 | | | | | | | | bin
@@ -32,30 +45,18 @@ exports[`installation 1`] = `
 | | | | | node_modules
 | | | | | | .cache
 | | | | | | | _esy
-| | | | | | | | build-eject
-| | | | | | | | | bin
-| | | | | | | | | | fastreplacestring.cpp
-| | | | | | | | | | fastreplacestring.exe
-| | | | | | | | | | get-store-path
-| | | | | | | | | | realpath
-| | | | | | | | | | realpath.c
-| | | | | | | | | | render-env
-| | | | | | | | | | runtime.sh
-| | | | | | | | | command-env
-| | | | | | | | | eject-env
-| | | | | | | | | Makefile
-| | | | | | | | | records
-| | | | | | | | | | final-install-path-set.txt
-| | | | | | | | | | final-install-path-set.txt.in
-| | | | | | | | | | store-path.txt
-| | | | | | | | | | store-path.txt.in
-| | | | | | | | | sandbox.sb.in
 | | | | | | | | store
 | | | | | | | | | b
 | | | | | | | | | i
 | | | | | | | | | s
 | | | | | package.json
-| | | | | test.js"
+| | | | | test.js
+| | | | records
+| | | | | done.txt
+| | | | | recordedClientBuildStorePath.txt
+| | | | | recordedClientInstallStorePath.txt
+| | | | | recordedCoppiedArtifacts.txt
+| | | | | recordedServerBuildStorePath.txt"
 `;
 
 exports[`installation stdout 1`] = `
@@ -82,12 +83,17 @@ exports[`release 1`] = `
 | | package.json
 | | postinstall.sh
 | | prerelease.sh
-| | rel.tar.gz"
+| | r.tar.gz
+| | records"
 `;
 
 exports[`release stdout 1`] = `
 "*** Creating pack-type release for minimal...
 *** Installing dependencies...
 *** Ejecting build environment...
-*** Packing the release..."
+*** Packing the release...
+*** Release package created
+
+    Location: _release/pack
+    Release Type: pack"
 `;

--- a/__tests__/release/__snapshots__/release-pack-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-pack-with-binary-test.js.snap
@@ -15,13 +15,26 @@ exports[`installation 1`] = `
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
-| | | | records
-| | | | | recordedClientBuildStorePath.txt
-| | | | | recordedClientInstallStorePath.txt
-| | | | | recordedCoppiedArtifacts.txt
-| | | | | recordedServerBuildStorePath.txt
-| | | | rel
-| | | | | 3.x.x__________________________
+| | | | r
+| | | | | _esyEjectRoot
+| | | | | | bin
+| | | | | | | fastreplacestring.cpp
+| | | | | | | fastreplacestring.exe
+| | | | | | | get-store-path
+| | | | | | | realpath
+| | | | | | | realpath.c
+| | | | | | | render-env
+| | | | | | | runtime.sh
+| | | | | | command-env
+| | | | | | eject-env
+| | | | | | Makefile
+| | | | | | records
+| | | | | | | final-install-path-set.txt
+| | | | | | | final-install-path-set.txt.in
+| | | | | | | store-path.txt
+| | | | | | | store-path.txt.in
+| | | | | | sandbox.sb.in
+| | | | | 3______________________________
 | | | | | | i
 | | | | | | | with_binary-0.1.0
 | | | | | | | | bin
@@ -35,31 +48,19 @@ exports[`installation 1`] = `
 | | | | | node_modules
 | | | | | | .cache
 | | | | | | | _esy
-| | | | | | | | build-eject
-| | | | | | | | | bin
-| | | | | | | | | | fastreplacestring.cpp
-| | | | | | | | | | fastreplacestring.exe
-| | | | | | | | | | get-store-path
-| | | | | | | | | | realpath
-| | | | | | | | | | realpath.c
-| | | | | | | | | | render-env
-| | | | | | | | | | runtime.sh
-| | | | | | | | | command-env
-| | | | | | | | | eject-env
-| | | | | | | | | Makefile
-| | | | | | | | | records
-| | | | | | | | | | final-install-path-set.txt
-| | | | | | | | | | final-install-path-set.txt.in
-| | | | | | | | | | store-path.txt
-| | | | | | | | | | store-path.txt.in
-| | | | | | | | | sandbox.sb.in
 | | | | | | | | store
 | | | | | | | | | b
 | | | | | | | | | i
 | | | | | | | | | s
 | | | | | package.json
 | | | | | say-hello.exe
-| | | | | test.js"
+| | | | | test.js
+| | | | records
+| | | | | done.txt
+| | | | | recordedClientBuildStorePath.txt
+| | | | | recordedClientInstallStorePath.txt
+| | | | | recordedCoppiedArtifacts.txt
+| | | | | recordedServerBuildStorePath.txt"
 `;
 
 exports[`installation stdout 1`] = `
@@ -88,12 +89,17 @@ exports[`release 1`] = `
 | | package.json
 | | postinstall.sh
 | | prerelease.sh
-| | rel.tar.gz"
+| | r.tar.gz
+| | records"
 `;
 
 exports[`release stdout 1`] = `
 "*** Creating pack-type release for with-binary...
 *** Installing dependencies...
 *** Ejecting build environment...
-*** Packing the release..."
+*** Packing the release...
+*** Release package created
+
+    Location: _release/pack
+    Release Type: pack"
 `;

--- a/__tests__/release/__snapshots__/release-pack-with-dep-with-binary-test.js.snap
+++ b/__tests__/release/__snapshots__/release-pack-with-dep-with-binary-test.js.snap
@@ -15,13 +15,30 @@ exports[`installation 1`] = `
 | | | | package.json
 | | | | postinstall.sh
 | | | | prerelease.sh
-| | | | records
-| | | | | recordedClientBuildStorePath.txt
-| | | | | recordedClientInstallStorePath.txt
-| | | | | recordedCoppiedArtifacts.txt
-| | | | | recordedServerBuildStorePath.txt
-| | | | rel
-| | | | | 3.x.x_________________
+| | | | r
+| | | | | _esyEjectRoot
+| | | | | | bin
+| | | | | | | fastreplacestring.cpp
+| | | | | | | fastreplacestring.exe
+| | | | | | | get-store-path
+| | | | | | | realpath
+| | | | | | | realpath.c
+| | | | | | | render-env
+| | | | | | | runtime.sh
+| | | | | | command-env
+| | | | | | eject-env
+| | | | | | Makefile
+| | | | | | node_modules
+| | | | | | | dep
+| | | | | | | | eject-env
+| | | | | | | | sandbox.sb.in
+| | | | | | records
+| | | | | | | final-install-path-set.txt
+| | | | | | | final-install-path-set.txt.in
+| | | | | | | store-path.txt
+| | | | | | | store-path.txt.in
+| | | | | | sandbox.sb.in
+| | | | | 3_____________________
 | | | | | | i
 | | | | | | | dep-0.1.0
 | | | | | | | | bin
@@ -44,38 +61,22 @@ exports[`installation 1`] = `
 | | | | | | dep
 | | | | | | | package.json
 | | | | | | | say-hello.exe
+| | | | | esy.lock
 | | | | | node_modules
 | | | | | | .cache
 | | | | | | | _esy
-| | | | | | | | build-eject
-| | | | | | | | | bin
-| | | | | | | | | | fastreplacestring.cpp
-| | | | | | | | | | fastreplacestring.exe
-| | | | | | | | | | get-store-path
-| | | | | | | | | | realpath
-| | | | | | | | | | realpath.c
-| | | | | | | | | | render-env
-| | | | | | | | | | runtime.sh
-| | | | | | | | | command-env
-| | | | | | | | | eject-env
-| | | | | | | | | Makefile
-| | | | | | | | | node_modules
-| | | | | | | | | | dep
-| | | | | | | | | | | eject-env
-| | | | | | | | | | | sandbox.sb.in
-| | | | | | | | | records
-| | | | | | | | | | final-install-path-set.txt
-| | | | | | | | | | final-install-path-set.txt.in
-| | | | | | | | | | store-path.txt
-| | | | | | | | | | store-path.txt.in
-| | | | | | | | | sandbox.sb.in
 | | | | | | | | store
 | | | | | | | | | b
 | | | | | | | | | i
 | | | | | | | | | s
 | | | | | package.json
 | | | | | test.js
-| | | | | yarn.lock"
+| | | | records
+| | | | | done.txt
+| | | | | recordedClientBuildStorePath.txt
+| | | | | recordedClientInstallStorePath.txt
+| | | | | recordedCoppiedArtifacts.txt
+| | | | | recordedServerBuildStorePath.txt"
 `;
 
 exports[`installation stdout 1`] = `
@@ -106,12 +107,17 @@ exports[`release 1`] = `
 | | package.json
 | | postinstall.sh
 | | prerelease.sh
-| | rel.tar.gz"
+| | r.tar.gz
+| | records"
 `;
 
 exports[`release stdout 1`] = `
 "*** Creating pack-type release for with-dep-with-binary...
 *** Installing dependencies...
 *** Ejecting build environment...
-*** Packing the release..."
+*** Packing the release...
+*** Release package created
+
+    Location: _release/pack
+    Release Type: pack"
 `;

--- a/src/constants.js
+++ b/src/constants.js
@@ -24,7 +24,7 @@ export const STORE_STAGE_TREE = 's';
 /**
  * The current version of esy store, bump it whenever the store layout changes.
  */
-export const ESY_STORE_VERSION = '3.x.x';
+export const ESY_STORE_VERSION = '3';
 
 /**
  * This is a limit imposed by POSIX.


### PR DESCRIPTION
This PR reduces the store prefix for releases by 6 chars (4 chars for any store & 2 chars specifically for release stores). This will invalidate existing Esy caches though... still think it's sensible to do.