### PR TITLE
Fix build-shell command to have the same env as build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## NEXT
+
+* Fix `esy build-shell` command to have exactly the same environment as `esy
+  build` operates in.
+
+* Allow to initialize a build shell for any package in a sandbox. Specify
+  a package by the path to its source:
+
+      % esy build-shell ./node_modules/@opam/reason
+
 ## 0.0.28
 
 * Support for installing packages with only `esy.json` available.

--- a/bin/esy
+++ b/bin/esy
@@ -131,8 +131,11 @@ printHelp() {
 
   print-env             Prints esy environment on stdout.
 
-  build-shell           Drops into a shell with environment matching your
-                        package's build environment.
+  build-shell [path]    Drops into a shell with environment matching your
+                        package's build environment. If argument is provided
+                        then it should point to the package inside the current
+                        sandbox — that will initialize build shell for that
+                        specified package.
 
   build-eject           Creates node_modules/.cache/esy/build-eject/Makefile,
                         which is later can be used for building without the NodeJS
@@ -185,7 +188,7 @@ then
   printHelp
 elif [ $# -eq 1 ]; then
   case $1 in
-    build-shell|clean)
+    clean)
       callBuiltInCommand__buildEject
       make -j -s -f "$BUILD_EJECT_PATH/Makefile" "$1"
       ;;
@@ -199,6 +202,10 @@ elif [ $# -eq 1 ]; then
     build|b)
       shift
       callBuiltInCommand build "$@"
+      ;;
+    build-shell)
+      shift
+      callBuiltInCommand build-shell "$@"
       ;;
     import-opam)
       shift
@@ -255,6 +262,10 @@ else
     add)
       shift
       callBuiltInCommand__esyInstall add "$@"
+      ;;
+    build-shell)
+      shift
+      callBuiltInCommand build-shell "$@"
       ;;
     install|i)
       shift

--- a/src/bin/esy.js
+++ b/src/bin/esy.js
@@ -73,10 +73,12 @@ function formatError(message: string, stack?: string) {
   return result;
 }
 
-function error(error: Error | string) {
-  const message = String(error.message ? error.message : error);
-  const stack = error.stack ? String(error.stack) : undefined;
-  console.log(formatError(message, stack));
+function error(error?: Error | string) {
+  if (error != null) {
+    const message = String(error.message ? error.message : error);
+    const stack = error.stack ? String(error.stack) : undefined;
+    console.log(formatError(message, stack));
+  }
   process.exit(1);
 }
 
@@ -92,12 +94,13 @@ export type CommandContext = {
   commandName: string,
   args: Array<string>,
 
-  error(message: string): void,
+  error(message?: string): any,
 };
 
 const commandsByName: {[name: string]: (CommandContext) => any} = {
   'build-eject': ctx => require('./esyBuildEject').default(ctx),
   build: ctx => require('./esyBuild').default(ctx),
+  'build-shell': ctx => require('./esyBuildShell').default(ctx),
   release: ctx => require('./esyRelease').default(ctx),
   'import-opam': ctx => require('./esyImportOpam').default(ctx),
   'print-env': ctx => require('./esyPrintEnv').default(ctx),

--- a/src/bin/esyBuildShell.js
+++ b/src/bin/esyBuildShell.js
@@ -1,0 +1,61 @@
+/**
+ * @flow
+ */
+
+import type {CommandContext} from './esy';
+import type {BuildTask} from '../types';
+
+import {settings as configureObservatory} from 'observatory';
+import chalk from 'chalk';
+import outdent from 'outdent';
+import * as path from 'path';
+
+import * as fs from '../lib/fs';
+import {indent, getBuildSandbox, getBuildConfig} from './esy';
+import * as Task from '../build-task';
+import * as Builder from '../builders/simple-builder';
+import {reportBuildError, createBuildProgressReporter} from './esyBuild';
+
+export default async function esyBuildShell(ctx: CommandContext) {
+  function findTaskBySourcePath(task: BuildTask, packageSourcePath) {
+    const predicate = task =>
+      path.join(config.sandboxPath, task.spec.sourcePath) === packageSourcePath;
+    const queue: BuildTask[] = [task];
+    while (queue.length > 0) {
+      const t = queue.shift();
+      if (predicate(t)) {
+        return t;
+      }
+      queue.push(...t.dependencies.values());
+    }
+
+    return ctx.error(
+      `unable to initialize build shell for ${packageSourcePath}: no such package found`,
+    );
+  }
+
+  const [packageSourcePath] = ctx.args;
+
+  const sandbox = await getBuildSandbox(ctx);
+  const config = await getBuildConfig(ctx);
+
+  const rootTask: BuildTask = Task.fromBuildSandbox(sandbox, config);
+
+  const task = packageSourcePath != null
+    ? findTaskBySourcePath(rootTask, path.resolve(process.cwd(), packageSourcePath))
+    : rootTask;
+
+  const reporter = createBuildProgressReporter();
+  const state = await Builder.buildDependencies(task, sandbox, config, reporter);
+  if (state.state === 'failure') {
+    const errors = Builder.collectBuildErrors(state);
+    for (const error of errors) {
+      reportBuildError(error);
+    }
+    ctx.error('build failed');
+  }
+
+  await Builder.withBuildDriver(task, config, sandbox, async driver => {
+    await driver.spawnInteractiveProcess('/bin/bash', []);
+  });
+}


### PR DESCRIPTION
Refactors simple builder into more granular primitives, adds `esy build-shell` command implementation based on it. Also allow:
```
% esy build-shell ./node_modules/@opam/reason
```
to debug builds of the specified packages.