### PR TITLE
Support devDependencies

### DIFF
--- a/__tests__/build/__snapshots__/build-with-dev-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dev-dep-test.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`build stdout 1`] = `
+"→ dep @ 1.0.0                                            
+[NaNA  → dep @ 1.0.0                                building... [NaNB[59D[NaNA  → dep @ 1.0.0                                      BUILT [NaNB[59D[NaNA  → dep @ 1.0.0                                      BUILT in NNNs[NaNB[66D  → dev-dep @ 1.0.0                                        
+[NaNA  → dev-dep @ 1.0.0                            building... [NaNB[59D[NaNA  → dev-dep @ 1.0.0                                  BUILT [NaNB[59D[NaNA  → dev-dep @ 1.0.0                                  BUILT in NNNs[NaNB[66D[0;32m  → [0mwith-dev-dep @ 1.0.0"
+`;
+
+exports[`dep exec stdout 1`] = `"dep"`;
+
+exports[`dev-dep exec stdout 1`] = `"dev-dep"`;
+
+exports[`esy local prefix dir 1`] = `
+"<root>
+| bin
+| | _build
+| | _shell
+| | build
+| | build-dependencies
+| | build-env
+| | command-env
+| | runtime.sh
+| | sandbox.sb
+| | shell
+| store
+| | b
+| | | with_dev_dep-1.0.0
+| | | | _esy
+| | | | | log
+| | | | with-dev-dep
+| | i
+| | s
+| | | with_dev_dep-1.0.0
+| | | | bin
+| | | | doc
+| | | | etc
+| | | | lib
+| | | | man
+| | | | sbin
+| | | | share"
+`;
+
+exports[`esy prefix dir 1`] = `
+"<root>
+| 3
+| | b
+| | | dep-1.0.0
+| | | | _esy
+| | | | | env
+| | | | | log
+| | | | | sandbox.sb
+| | | | dep
+| | | dev_dep-1.0.0
+| | | | _esy
+| | | | | env
+| | | | | log
+| | | | | sandbox.sb
+| | | | dev-dep
+| | i
+| | | dep-1.0.0
+| | | | bin
+| | | | | dep
+| | | | doc
+| | | | etc
+| | | | lib
+| | | | man
+| | | | sbin
+| | | | share
+| | | | stublibs
+| | | dev_dep-1.0.0
+| | | | bin
+| | | | | dev-dep
+| | | | doc
+| | | | etc
+| | | | lib
+| | | | man
+| | | | sbin
+| | | | share
+| | | | stublibs
+| | s
+| 3_____________________________________________________________________
+| | b
+| | | dep-1.0.0
+| | | | _esy
+| | | | | env
+| | | | | log
+| | | | | sandbox.sb
+| | | | dep
+| | | dev_dep-1.0.0
+| | | | _esy
+| | | | | env
+| | | | | log
+| | | | | sandbox.sb
+| | | | dev-dep
+| | i
+| | | dep-1.0.0
+| | | | bin
+| | | | | dep
+| | | | doc
+| | | | etc
+| | | | lib
+| | | | man
+| | | | sbin
+| | | | share
+| | | | stublibs
+| | | dev_dep-1.0.0
+| | | | bin
+| | | | | dev-dep
+| | | | doc
+| | | | etc
+| | | | lib
+| | | | man
+| | | | sbin
+| | | | share
+| | | | stublibs
+| | s"
+`;

--- a/__tests__/build/build-with-dev-dep-test.js
+++ b/__tests__/build/build-with-dev-dep-test.js
@@ -1,0 +1,47 @@
+/**
+ * @flow
+ */
+
+jest.setTimeout(200000);
+
+import * as path from 'path';
+import {initFixtureSync, readDirectory, cleanUp} from '../release/utils';
+
+const fixture = initFixtureSync(path.join(__dirname, 'fixtures', 'with-dev-dep'));
+
+test(`build ${fixture.description}`, async function() {
+  const buildStdout = await fixture.esy(['build'], {cwd: fixture.project});
+  expect(buildStdout).toMatchSnapshot('build stdout');
+
+  const esyPrefixDir = await readDirectory(path.join(fixture.esyPrefix));
+  expect(esyPrefixDir).toMatchSnapshot('esy prefix dir');
+
+  const esyLocalPrefixDir = await readDirectory(fixture.localEsyPrefix);
+  expect(esyLocalPrefixDir).toMatchSnapshot('esy local prefix dir');
+
+  // dep executable is available in command-env
+  const depExecStdout = await fixture.esy(['dep'], {cwd: fixture.project});
+  expect(depExecStdout).toMatchSnapshot('dep exec stdout');
+
+  // dev-dep executable is available in command-env
+  const devDepExecStdout = await fixture.esy(['dev-dep'], {cwd: fixture.project});
+  expect(devDepExecStdout).toMatchSnapshot('dev-dep exec stdout');
+
+  // dev-dep executable is not available in build-env
+  expectError(
+    fixture.esy(['build', 'which', 'dev-dep'], {
+      cwd: fixture.project,
+    }),
+  );
+});
+
+async function expectError(promise) {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  expect(false).toBe(true);
+}
+
+afterAll(cleanUp);

--- a/__tests__/build/fixtures/with-dev-dep/node_modules/dep/package.json
+++ b/__tests__/build/fixtures/with-dev-dep/node_modules/dep/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dep",
+  "version": "1.0.0",
+  "license": "MIT",
+  "esy": {
+    "build": [
+      "echo '#!/bin/bash\necho $cur__name' > $cur__target_dir/$cur__name",
+      "chmod +x $cur__target_dir/$cur__name"
+    ],
+    "install": [
+      "cp $cur__target_dir/$cur__name $cur__bin/$cur__name"
+    ]
+  },
+  "_resolved": "http://sometarball.gz"
+}

--- a/__tests__/build/fixtures/with-dev-dep/node_modules/dev-dep/package.json
+++ b/__tests__/build/fixtures/with-dev-dep/node_modules/dev-dep/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dev-dep",
+  "version": "1.0.0",
+  "license": "MIT",
+  "esy": {
+    "build": [
+      "echo '#!/bin/bash\necho $cur__name' > $cur__target_dir/$cur__name",
+      "chmod +x $cur__target_dir/$cur__name"
+    ],
+    "install": [
+      "cp $cur__target_dir/$cur__name $cur__bin/$cur__name"
+    ]
+  },
+  "_resolved": "http://sometarball.gz"
+}

--- a/__tests__/build/fixtures/with-dev-dep/package.json
+++ b/__tests__/build/fixtures/with-dev-dep/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "with-dev-dep",
+  "version": "1.0.0",
+  "license": "MIT",
+  "esy": {
+    "build": [
+      "echo '#!/bin/bash\necho $cur__name' > $cur__target_dir/$cur__name",
+      "chmod +x $cur__target_dir/$cur__name"
+    ],
+    "install": [
+      "cp $cur__target_dir/$cur__name $cur__bin/$cur__name"
+    ]
+  },
+  "dependencies": {
+    "dep": "*"
+  },
+  "devDependencies": {
+    "dev-dep": "*"
+  }
+}

--- a/src/__tests__/__snapshots__/build-sandbox-test.js.snap
+++ b/src/__tests__/__snapshots__/build-sandbox-test.js.snap
@@ -15,6 +15,8 @@ Object {
       "installCommand": Array [],
       "name": "dep",
       "packageJson": Object {
+        "dependencies": Object {},
+        "devDependencies": Object {},
         "esy": Object {
           "build": null,
           "buildsInSource": false,
@@ -22,6 +24,7 @@ Object {
           "install": null,
         },
         "name": "dep",
+        "peerDependencies": Object {},
         "version": "0.1.0",
       },
       "shouldBePersisted": false,
@@ -39,6 +42,7 @@ Object {
     "dependencies": Object {
       "dep": "*",
     },
+    "devDependencies": Object {},
     "esy": Object {
       "build": null,
       "buildsInSource": false,
@@ -46,6 +50,7 @@ Object {
       "install": null,
     },
     "name": "app",
+    "peerDependencies": Object {},
     "version": "0.1.0",
   },
   "shouldBePersisted": false,
@@ -66,6 +71,8 @@ Object {
   "installCommand": Array [],
   "name": "app",
   "packageJson": Object {
+    "dependencies": Object {},
+    "devDependencies": Object {},
     "esy": Object {
       "build": null,
       "buildsInSource": false,
@@ -73,6 +80,7 @@ Object {
       "install": null,
     },
     "name": "app",
+    "peerDependencies": Object {},
     "version": "0.1.0",
   },
   "shouldBePersisted": false,
@@ -105,6 +113,7 @@ Object {
         "dependencies": Object {
           "app": "*",
         },
+        "devDependencies": Object {},
         "esy": Object {
           "build": null,
           "buildsInSource": false,
@@ -112,6 +121,7 @@ Object {
           "install": null,
         },
         "name": "dep",
+        "peerDependencies": Object {},
         "version": "0.1.0",
       },
       "shouldBePersisted": false,
@@ -134,6 +144,7 @@ Object {
     "dependencies": Object {
       "dep": "*",
     },
+    "devDependencies": Object {},
     "esy": Object {
       "build": null,
       "buildsInSource": false,
@@ -141,6 +152,7 @@ Object {
       "install": null,
     },
     "name": "app",
+    "peerDependencies": Object {},
     "version": "0.1.0",
   },
   "shouldBePersisted": false,
@@ -170,6 +182,7 @@ Object {
     "dependencies": Object {
       "dep": "*",
     },
+    "devDependencies": Object {},
     "esy": Object {
       "build": null,
       "buildsInSource": false,
@@ -177,6 +190,7 @@ Object {
       "install": null,
     },
     "name": "app",
+    "peerDependencies": Object {},
     "version": "0.1.0",
   },
   "shouldBePersisted": false,

--- a/src/bin/esy.js
+++ b/src/bin/esy.js
@@ -9,7 +9,7 @@ import type {Options as SandboxOptions} from '../build-sandbox';
 
 import loudRejection from 'loud-rejection';
 import userHome from 'user-home';
-import * as path from 'path';
+import * as path from '../lib/path';
 import chalk from 'chalk';
 import parse from 'cli-argparse';
 
@@ -64,7 +64,9 @@ export async function getBuildSandbox(
   return sandbox;
 }
 
-export async function getBuildConfig(ctx: CommandContext) {
+export async function getBuildConfig(
+  ctx: CommandContext,
+): Promise<Config<path.AbsolutePath>> {
   const {createForPrefix} = require('../config');
 
   return createForPrefix({

--- a/src/bin/esy.js
+++ b/src/bin/esy.js
@@ -4,7 +4,7 @@
 
 require('babel-polyfill');
 
-import type {Config, BuildSandbox, BuildTask, BuildPlatform} from '../types';
+import type {Config, Sandbox, BuildTask, BuildPlatform} from '../types';
 import type {Options as SandboxOptions} from '../build-sandbox';
 
 import loudRejection from 'loud-rejection';
@@ -49,10 +49,10 @@ function getBuildPlatform() {
   }
 }
 
-export async function getBuildSandbox(
+export async function getSandbox(
   ctx: CommandContext,
   options?: SandboxOptions,
-): Promise<BuildSandbox> {
+): Promise<Sandbox> {
   const Sandbox = require('../build-sandbox');
   const sandbox = await Sandbox.fromDirectory(ctx.sandboxPath, options);
   if (sandbox.root.errors.length > 0) {

--- a/src/bin/esyBuild.js
+++ b/src/bin/esyBuild.js
@@ -11,7 +11,7 @@ import outdent from 'outdent';
 
 import * as fs from '../lib/fs';
 import * as path from '../lib/path';
-import {indent, getBuildSandbox, getBuildConfig} from './esy';
+import {indent, getSandbox, getBuildConfig} from './esy';
 import * as Sandbox from '../build-sandbox';
 import * as Task from '../build-task';
 import * as Builder from '../builders/simple-builder';
@@ -118,9 +118,9 @@ export function reportBuildError(error: Builder.BuildError) {
 }
 
 export default async function esyBuild(ctx: CommandContext) {
-  const sandbox = await getBuildSandbox(ctx);
+  const sandbox = await getSandbox(ctx);
   const config = await getBuildConfig(ctx);
-  const task: BuildTask = Task.fromBuildSandbox(sandbox, config);
+  const task: BuildTask = Task.fromSandbox(sandbox, config);
   const reporter = ctx.options.flags.silent ? undefined : createBuildProgressReporter();
 
   let ejectingBuild = null;

--- a/src/bin/esyBuildEject.js
+++ b/src/bin/esyBuildEject.js
@@ -9,7 +9,7 @@ import * as path from 'path';
 import invariant from 'invariant';
 import outdent from 'outdent';
 
-import {getBuildSandbox} from './esy';
+import {getSandbox} from './esy';
 import * as Config from '../config';
 import * as MakefileBuilder from '../builders/makefile-builder';
 
@@ -20,7 +20,7 @@ export default async function buildEjectCommand(ctx: CommandContext) {
     buildPlatformArg,
     ctx.buildPlatform,
   );
-  const sandbox = await getBuildSandbox(ctx, {forRelease: true});
+  const sandbox = await getSandbox(ctx, {forRelease: true});
   const buildConfig = createConfig(buildPlatform);
   MakefileBuilder.eject(
     sandbox,

--- a/src/bin/esyBuildShell.js
+++ b/src/bin/esyBuildShell.js
@@ -47,7 +47,7 @@ export default async function esyBuildShell(ctx: CommandContext) {
       : rootTask;
 
   const reporter = createBuildProgressReporter();
-  const state = await Builder.buildDependencies(task, sandbox, config, reporter);
+  const state = await Builder.buildDependencies(task, config, reporter);
   if (state.state === 'failure') {
     const errors = Builder.collectBuildErrors(state);
     for (const error of errors) {
@@ -56,7 +56,7 @@ export default async function esyBuildShell(ctx: CommandContext) {
     ctx.error('build failed');
   }
 
-  await Builder.withBuildDriver(task, config, sandbox, async driver => {
+  await Builder.withBuildDriver(task, config, async driver => {
     await driver.spawnInteractiveProcess('/bin/bash', []);
   });
 }

--- a/src/bin/esyBuildShell.js
+++ b/src/bin/esyBuildShell.js
@@ -11,7 +11,7 @@ import outdent from 'outdent';
 import * as path from 'path';
 
 import * as fs from '../lib/fs';
-import {indent, getBuildSandbox, getBuildConfig} from './esy';
+import {indent, getSandbox, getBuildConfig} from './esy';
 import * as Task from '../build-task';
 import * as Builder from '../builders/simple-builder';
 import {reportBuildError, createBuildProgressReporter} from './esyBuild';
@@ -36,10 +36,10 @@ export default async function esyBuildShell(ctx: CommandContext) {
 
   const [packageSourcePath] = ctx.args;
 
-  const sandbox = await getBuildSandbox(ctx);
+  const sandbox = await getSandbox(ctx);
   const config = await getBuildConfig(ctx);
 
-  const rootTask: BuildTask = Task.fromBuildSandbox(sandbox, config);
+  const rootTask: BuildTask = Task.fromSandbox(sandbox, config);
 
   const task =
     packageSourcePath != null

--- a/src/bin/esyPrintEnv.js
+++ b/src/bin/esyPrintEnv.js
@@ -15,7 +15,6 @@ export default async function esyPrintEnv(ctx: CommandContext) {
   // the build processes, staleness, package validity etc.
   const sandbox = await getSandbox(ctx);
   const config = await getBuildConfig(ctx);
-  const task = Task.fromSandbox(sandbox, config);
-  const env = Sandbox.getCommandEnv(task, config);
-  console.log(Env.printEnvironment(task.env));
+  const env = Sandbox.getCommandEnv(sandbox, config);
+  console.log(Env.printEnvironment(env));
 }

--- a/src/bin/esyPrintEnv.js
+++ b/src/bin/esyPrintEnv.js
@@ -4,7 +4,7 @@
 
 import type {CommandContext} from './esy';
 
-import {getBuildSandbox, getBuildConfig} from './esy';
+import {getSandbox, getBuildConfig} from './esy';
 import * as Task from '../build-task';
 import * as Sandbox from '../sandbox';
 import * as Env from '../environment';
@@ -13,9 +13,9 @@ export default async function esyPrintEnv(ctx: CommandContext) {
   // TODO: It's just a status command. Print the command that would be
   // used to setup the environment along with status of
   // the build processes, staleness, package validity etc.
-  const sandbox = await getBuildSandbox(ctx);
+  const sandbox = await getSandbox(ctx);
   const config = await getBuildConfig(ctx);
-  const task = Task.fromBuildSandbox(sandbox, config);
+  const task = Task.fromSandbox(sandbox, config);
   const env = Sandbox.getCommandEnv(task, config);
   console.log(Env.printEnvironment(task.env));
 }

--- a/src/build-sandbox.js
+++ b/src/build-sandbox.js
@@ -4,7 +4,7 @@
 
 import type {
   BuildSpec,
-  BuildSandbox,
+  Sandbox,
   BuildEnvironment,
   EnvironmentVarExport,
   EsySpec,
@@ -57,7 +57,7 @@ export type Options = {
 export async function fromDirectory(
   sandboxPath: string,
   options: Options = {},
-): Promise<BuildSandbox> {
+): Promise<Sandbox> {
   // Caching module resolution actually speed ups sandbox crawling a lot.
   const resolutionCache: Map<string, Promise<string>> = new Map();
 
@@ -365,3 +365,4 @@ function normalizeCommand(
     return command;
   }
 }
+

--- a/src/build-task.js
+++ b/src/build-task.js
@@ -3,7 +3,7 @@
  */
 
 import type {
-  BuildSandbox,
+  Sandbox,
   BuildSpec,
   Config,
   BuildTask,
@@ -380,8 +380,8 @@ export function expandWithScope<T: {value: string}>(
   return {rendered: rendered != null ? rendered : value};
 }
 
-export function fromBuildSandbox<Path: path.Path>(
-  sandbox: BuildSandbox,
+export function fromSandbox<Path: path.Path>(
+  sandbox: Sandbox,
   config: Config<Path>,
   params?: BuildTaskParams,
 ): BuildTask {

--- a/src/builders/makefile-builder.js
+++ b/src/builders/makefile-builder.js
@@ -403,7 +403,7 @@ export function eject(sandbox: Sandbox, outputPath: string, config: Config<path.
         export ESY_EJECT__STORE=$(esyGetStorePathFromPrefix "$HOME/.esy")
       fi
 
-      ${Env.printEnvironment(S.getSandboxEnv(rootTask, config))}
+      ${Env.printEnvironment(S.getSandboxEnv(sandbox, config))}
     `,
   };
 

--- a/src/builders/makefile-builder.js
+++ b/src/builders/makefile-builder.js
@@ -2,13 +2,7 @@
  * @flow
  */
 
-import type {
-  BuildSpec,
-  BuildTask,
-  BuildTaskCommand,
-  Config,
-  BuildSandbox,
-} from '../types';
+import type {BuildSpec, BuildTask, BuildTaskCommand, Config, Sandbox} from '../types';
 
 import {sync as mkdirp} from 'mkdirp';
 import createLogger from 'debug';
@@ -16,7 +10,7 @@ import outdent from 'outdent';
 
 import * as Graph from '../graph';
 import * as Task from '../build-task';
-import * as Sandbox from '../sandbox';
+import * as S from '../sandbox';
 import * as Env from '../environment';
 import * as Makefile from '../Makefile';
 import {normalizePackageName} from '../util';
@@ -194,11 +188,7 @@ const defineSandboxEnvRule = Makefile.createDefine({
 /**
  * Render `build` as Makefile (+ related files) into the supplied `outputPath`.
  */
-export function eject(
-  sandbox: BuildSandbox,
-  outputPath: string,
-  config: Config<path.Path>,
-) {
+export function eject(sandbox: Sandbox, outputPath: string, config: Config<path.Path>) {
   const buildFiles = [];
 
   function generateMetaRule({filename}) {
@@ -335,7 +325,7 @@ export function eject(
 
   // Emit build artefacts for packages
   log('process dependency graph');
-  const rootTask = Task.fromBuildSandbox(sandbox, config);
+  const rootTask = Task.fromSandbox(sandbox, config);
 
   const finalInstallPathSetMetaRule = generateMetaRule({
     filename: 'final-install-path-set.txt',
@@ -413,7 +403,7 @@ export function eject(
         export ESY_EJECT__STORE=$(esyGetStorePathFromPrefix "$HOME/.esy")
       fi
 
-      ${Env.printEnvironment(Sandbox.getSandboxEnv(rootTask, config))}
+      ${Env.printEnvironment(S.getSandboxEnv(rootTask, config))}
     `,
   };
 

--- a/src/builders/shell-builder.js
+++ b/src/builders/shell-builder.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import type {BuildTask, BuildTaskCommand, BuildSandbox, Config} from '../types';
+import type {BuildTask, BuildTaskCommand, Sandbox, Config} from '../types';
 
 import * as os from 'os';
 import outdent from 'outdent';
@@ -16,7 +16,7 @@ import * as Graph from '../graph';
 import {renderSandboxSbConfig} from './util';
 import {defineScriptDir} from './bashgen';
 import {renderEnv} from '../Makefile';
-import * as Sandbox from '../sandbox';
+import * as S from '../sandbox';
 import {renderBuildTaskCommand} from './makefile-builder';
 
 const log = createLogger('esy:shell-builder');
@@ -26,7 +26,7 @@ const RUNTIME = fs.readFileSync(require.resolve('./shell-builder.sh'));
 export const eject = async (
   outputPath: string,
   task: BuildTask,
-  sandbox: BuildSandbox,
+  sandbox: Sandbox,
   config: Config<path.AbsolutePath>,
 ) => {
   const immutableDeps = [];
@@ -69,7 +69,7 @@ export const eject = async (
 
   await emitFile({
     filename: ['bin/command-env'],
-    contents: environment.printEnvironment(Sandbox.getCommandEnv(task, config)),
+    contents: environment.printEnvironment(S.getCommandEnv(task, config)),
   });
 
   await emitFile({

--- a/src/builders/simple-builder.js
+++ b/src/builders/simple-builder.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import type {BuildTask, BuildSpec, Store, Config, BuildSandbox} from '../types';
+import type {BuildTask, BuildSpec, Store, Config, Sandbox} from '../types';
 
 import invariant from 'invariant';
 import createLogger from 'debug';

--- a/src/types.js
+++ b/src/types.js
@@ -202,6 +202,7 @@ export type Config<+Path: path.Path, RPath: Path = Path> = {
 export type BuildSandbox = {
   env: BuildEnvironment,
   root: BuildSpec,
+  devDependencies: Map<string, BuildSpec>,
 };
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -199,7 +199,7 @@ export type Config<+Path: path.Path, RPath: Path = Path> = {
  * Note that usually builds do not exist outside of build sandboxes as their own
  * identities a made dependent on a global env of the sandbox.
  */
-export type BuildSandbox = {
+export type Sandbox = {
   env: BuildEnvironment,
   root: BuildSpec,
   devDependencies: Map<string, BuildSpec>,


### PR DESCRIPTION
Fixes #24 

* Use `devDependencies` when constructing `command-env`.
* Ignore `devDependencies` (as before) when constructing `build-env`.